### PR TITLE
Fix: Snap generating fresh dynamic assemblies each invocation

### DIFF
--- a/Snap.LinFu/AspectPostProcessor.cs
+++ b/Snap.LinFu/AspectPostProcessor.cs
@@ -30,6 +30,8 @@ namespace Snap.LinFu
 {
     public class AspectPostProcessor : IPostProcessor
     {
+    	private readonly ProxyFactory _proxyFactory = new ProxyFactory(new ProxyGenerator());
+
         public void PostProcess(IServiceRequestResult result)
         {
             var instance = result.ActualResult;
@@ -60,17 +62,7 @@ namespace Snap.LinFu
                 return;
             }
 
-            var pseudoList = new IInterceptor[proxy.Configuration.Interceptors.Count];
-            pseudoList[0] = proxy;
-
-            for (var i = 1; i < pseudoList.Length; i++)
-            {
-                pseudoList[i] = new PseudoInterceptor();
-            }
-
-            var targetInterface = instance.GetType().GetTypeToDynamicProxy(proxy.Configuration.Namespaces);
-
-            result.ActualResult = AspectUtility.CreateProxy(targetInterface, instance, pseudoList);
+        	result.ActualResult = _proxyFactory.CreateProxy(instance, proxy);
         }
     }
 }

--- a/Snap.Ninject/AspectProxyActivationStrategy.cs
+++ b/Snap.Ninject/AspectProxyActivationStrategy.cs
@@ -33,6 +33,8 @@ namespace Snap.Ninject
     /// </summary>
     public class AspectProxyActivationStrategy : ActivationStrategy
     {
+        private ProxyFactory _proxyFactory = new ProxyFactory(new ProxyGenerator());
+
         /// <summary>
         /// Creates and wraps the reference type in a Castle proxy
         /// </summary>
@@ -48,12 +50,7 @@ namespace Snap.Ninject
                 // Only build a proxy for decorated types
                 if (reference.Instance.IsDecorated(proxy.Configuration))
                 {
-                    var type = reference.Instance.GetType();
-
-                    // Filter the interfaces by given namespaces that implement IInterceptAspect
-                    var targetInterface = type.GetTypeToDynamicProxy(proxy.Configuration.Namespaces);
-
-                    reference.Instance = AspectUtility.CreatePseudoProxy(proxy, targetInterface, reference.Instance);
+                    reference.Instance = _proxyFactory.CreateProxy(reference.Instance, proxy);
                 }
             }
 

--- a/Snap/ProxyFactory.cs
+++ b/Snap/ProxyFactory.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Castle.DynamicProxy;
+using Fasterflect;
+
+namespace Snap
+{
+    /// <summary>
+    /// Incapsulates proxy creation logic, delegates actual proxy creation to ProxyGenerator of DynamicProxy2 assembly
+    /// </summary>
+    public class ProxyFactory
+    {
+        private readonly ProxyGenerator _proxyGenerator;
+
+        public ProxyFactory(ProxyGenerator proxyGenerator)
+        {
+            _proxyGenerator = proxyGenerator;
+        }
+
+        public object CreateProxy(object instanceToProxy, IMasterProxy masterProxy)
+        {
+            object proxy;
+            var interfaceToProxy = GetInterfaceToProxy(instanceToProxy.GetType(), masterProxy.Configuration);
+            var interceptorsOfProxy = GetInterceptors(masterProxy);
+            if(interfaceToProxy.IsInterface)
+            {
+                proxy = _proxyGenerator.CreateInterfaceProxyWithTargetInterface(
+                    interfaceToProxy,
+                    instanceToProxy,
+                    interceptorsOfProxy);
+            }
+            else
+            {
+                var greediestCtor = interfaceToProxy.GetConstructors().OrderBy(x => x.Parameters().Count).LastOrDefault();
+                var ctorDummyArgs =  greediestCtor == null ? new object[0] : new object[greediestCtor.Parameters().Count];
+                proxy = _proxyGenerator.CreateClassProxyWithTarget(
+                    interfaceToProxy,
+                    instanceToProxy,
+                    ctorDummyArgs, 
+                    interceptorsOfProxy);
+            }
+            return proxy;
+        }
+        
+        /// <summary>
+        /// Determines the type of DynamicProxy that will be created over the given type.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public Type GetInterfaceToProxy(Type type, AspectConfiguration configuration)
+        {
+            var allInterfaces = type.GetInterfaces();
+
+            IEnumerable<Type> baseClassInterfaces = type.BaseType != null ? type.BaseType.GetInterfaces() : new Type[0];
+            IEnumerable<Type> topLevelInterfaces = allInterfaces.Except(baseClassInterfaces);
+
+            if (topLevelInterfaces.Count() == 0)
+            {
+                var types = new[] { type };
+                return types.FirstMatch(configuration.Namespaces);
+            }
+
+            return allInterfaces.FirstMatch(configuration.Namespaces);
+        }
+
+        private IInterceptor[] GetInterceptors(IMasterProxy masterProxy)
+        {
+            return new[] { masterProxy }.Concat(Enumerable
+                .Range(1, masterProxy.Configuration.Interceptors.Count - 1)
+                .Select(i => new PseudoInterceptor())
+                .Cast<IInterceptor>())
+                .ToArray();
+        }
+
+    }
+}

--- a/Snap/Snap.csproj
+++ b/Snap/Snap.csproj
@@ -99,6 +99,7 @@
     <Compile Include="DefaultConventionScanner.cs" />
     <Compile Include="AspectBookSyntax.cs" />
     <Compile Include="Interfaces\IAspectBookSyntax.cs" />
+    <Compile Include="ProxyFactory.cs" />
     <Compile Include="Strategies\ResolveInterceptorFromContainerCreationStrategy.cs" />
     <Compile Include="Strategies\InstantiateInterceptorDirectlyCreationStrategy.cs" />
     <Compile Include="Interfaces\IInterceptorCreationStrategy.cs" />


### PR DESCRIPTION
This is a fix to https://github.com/TylerBrinks/Snap/issues/19.

<strong>Buggy behavior:</strong>

<p>
Snap loads two new assemblies: DynamicProxyGenAssembly2 (unsigned) and DynamicProxyGenAssembly2 (signed) in current app domain every time dynamic proxy is created via ProxyGenerator class.
</p>


<strong>Fixed behavior.<strong>

<p>
Snap will generate DynamicProxyGenAssembly2 per each container configuration instead. 
That is, pair of DynamicProxyGenAssembly2(singed and unsigned) for LinFu container configuration.
<pre>
SnapConfiguration.For(new LinFuAspectContainer(container)).Configure(c =>
 {
    ...
}
</pre>

Pair of DynamicProxyGenAssembly2 for Autofac container configuration.
<pre>
SnapConfiguration.For(new AutofacAspectContainer(builder)).Configure(c =>
{
    ...
}
</pre>
Usually, as you are using your single favorite container, you will end up with only single pair of DynamicProxyGenAssembly2 loaded to the app domain.
</p>
     

Also, I've refactored AspectUtility static class and extract ProxyFactory class from it.
